### PR TITLE
move some modules to Experimental section

### DIFF
--- a/src/ocat.ml
+++ b/src/ocat.ml
@@ -3,8 +3,12 @@ include Fix
 include Monoid
 include Monad
 include Comonad
-include Free
-include Cofree
 
 module Ocat_modules = Ocat_modules
-module Ocat_transformers = Ocat_transformers
+
+module Experimental = struct
+  include Free
+  include Cofree
+
+  module Ocat_transformers = Ocat_transformers
+end

--- a/test/test_monad_transformers.ml
+++ b/test/test_monad_transformers.ml
@@ -3,7 +3,7 @@ open Fmt
 
 open Ocat
 open Ocat.Ocat_modules
-open Ocat.Ocat_transformers
+open Ocat.Experimental.Ocat_transformers
 
 module I64 = struct
   include Int64


### PR DESCRIPTION
fixes #14 

- cofree
  * uncertain about the `Lazy` tail
- free
  * most of the usability of free seems to come from higher-kinded
    types, not clear what we can do with `Free` in ocaml
- monad transformers
  * might be to much overhead for usability
  * lifting is probably implemented incorrectly